### PR TITLE
Update deprecated functions

### DIFF
--- a/webimport/webimport.py
+++ b/webimport/webimport.py
@@ -7,6 +7,7 @@ import encodings.idna
 import http.client
 import importlib
 import importlib.abc
+import importlib.util
 import logging
 import sys
 
@@ -49,7 +50,7 @@ class WebImporter(importlib.abc.SourceLoader, importlib.abc.MetaPathFinder):
             logging.debug("[%s]  |- Not chached. Searching..."%fullname)
             status[0] = _MOD_SEARCHING_
             self.modules[fullname] = status
-            loader = importlib.find_loader(fullname)
+            loader = importlib.util.find_spec(fullname)
             status[0] = _MOD_IS_PRESENT_ if loader else _MOD_NOT_PRESENT_
             self.modules[fullname] = status
         if bool(status[0]):
@@ -104,13 +105,14 @@ class WebImporter(importlib.abc.SourceLoader, importlib.abc.MetaPathFinder):
         return None
 
 
-    def find_spec(self, fullname, *args, **kwargs):
-        if not self.find_module(fullname):
+    def find_spec(self, fullname, path, target=None):
+        if not self.find_module(fullname,path):
             return None
         logging.info("[%s]  |- Loading spec"%fullname)
         if self.is_package(fullname):
             logging.debug("[%s]  |   |- Spec is a package"%fullname)
-        spec = importlib.machinery.ModuleSpec(fullname, self, is_package=self.is_package(fullname))
+        #spec = importlib.machinery.ModuleSpec(fullname, self, origin=self.modules.get(fullname)[1], is_package=self.is_package(fullname))
+        spec = importlib.util.spec_from_loader(fullname,self,origin=self.modules.get(fullname)[1], is_package=self.is_package(fullname))
         return spec
 
 


### PR DESCRIPTION
Hi Pieter-Jan,

I hope you are doing well.  I still tell everyone in SEC573 how you updated this module from Python2 to 3.  

I had some trouble importing packages.  It worked fine on single file modules, but on packages it was failing.    I replaced a couple of functions and now it is working for more complex packages like scapy.

Please fine the attached pull request to fix the issue.  

Do you plan to continue to actively maintain this project?   If so there is another issue that needs to be addressed.  When I import the requests module it does fine until it gets to a resource such as "certifi.pem".  Then it can not find it.